### PR TITLE
Copy configuration values from bambora pay

### DIFF
--- a/Setup/Patch/Data/UpdateConfiguration.php
+++ b/Setup/Patch/Data/UpdateConfiguration.php
@@ -1,14 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Epay\Payment\Setup\Patch\Data;
 
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-/**
- * UpdateConfiguration Data Patch Class to remove old config values
- */
 class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterface
 {
     /**
@@ -33,7 +32,6 @@ class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterfac
     {
         $this->updateConfiguration();
     }
-
     /**
      * Revert the data patch.
      */
@@ -41,7 +39,6 @@ class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterfac
     {
         return true;
     }
-
     /**
      * Retrieve aliases for the data patch.
      *
@@ -51,17 +48,16 @@ class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterfac
     {
         return [];
     }
-
     /**
      * Retrieve dependencies for the data patch.
      *
      * @return array
      */
+
     public static function getDependencies()
     {
         return [];
     }
-
     /**
      * Update the config Values in core_config_data table
      */
@@ -75,19 +71,14 @@ class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterfac
         $oldConfigValues = $connection->fetchAll($select);
     
         foreach ($oldConfigValues as $oldConfig) {
-            // Skip certain paths
             if ($oldConfig['path'] === 'payment/bambora_epay/active' || $oldConfig['path'] === 'payment/bambora_epay/title') {
-                continue; // Skip this iteration
+                continue; 
             }
-    
-            // Define the new path here
-            $path = str_replace('payment/bambora_epay', 'payment/epay', $oldConfig['path']);
-    
-            // Insert the new values into the database
+            $newPath = str_replace('payment/bambora_epay', 'payment/epay', $oldConfig['path']);
             $connection->insert($configTable, [
                 'scope' => $oldConfig['scope'],
                 'scope_id' => $oldConfig['scope_id'],
-                'path' => $path, // Use the new path
+                'path' => $newPath,
                 'value' => $oldConfig['value'],
             ]);
         }

--- a/Setup/Patch/Data/UpdateConfiguration.php
+++ b/Setup/Patch/Data/UpdateConfiguration.php
@@ -2,7 +2,6 @@
 
 namespace Epay\Payment\Setup\Patch\Data;
 
-// use InMobile\InMobile\Helper\Data;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchRevertableInterface;

--- a/Setup/Patch/Data/UpdateConfiguration.php
+++ b/Setup/Patch/Data/UpdateConfiguration.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Epay\Payment\Setup\Patch\Data;
+
+// use InMobile\InMobile\Helper\Data;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
+
+/**
+ * UpdateConfiguration Data Patch Class to remove old config values
+ */
+class UpdateConfiguration implements DataPatchInterface, PatchRevertableInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * UpdateConfiguration Data Patch constructor
+     *
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+    /**
+     * Apply the data patch.
+     */
+    public function apply()
+    {
+        $this->updateConfiguration();
+    }
+
+    /**
+     * Revert the data patch.
+     */
+    public function revert()
+    {
+        return true;
+    }
+
+    /**
+     * Retrieve aliases for the data patch.
+     *
+     * @return array
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+
+    /**
+     * Retrieve dependencies for the data patch.
+     *
+     * @return array
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * Update the config Values in core_config_data table
+     */
+    private function updateConfiguration()
+    {
+        $configTable = $this->moduleDataSetup->getTable('core_config_data');
+        $connection = $this->moduleDataSetup->getConnection();
+    
+        $select = $connection->select()->from($configTable)
+            ->where('path LIKE ?', '%payment/bambora_epay%');
+        $oldConfigValues = $connection->fetchAll($select);
+    
+        foreach ($oldConfigValues as $oldConfig) {
+            // Skip certain paths
+            if ($oldConfig['path'] === 'payment/bambora_epay/active' || $oldConfig['path'] === 'payment/bambora_epay/title') {
+                continue; // Skip this iteration
+            }
+    
+            // Define the new path here
+            $path = str_replace('payment/bambora_epay', 'payment/epay', $oldConfig['path']);
+    
+            // Insert the new values into the database
+            $connection->insert($configTable, [
+                'scope' => $oldConfig['scope'],
+                'scope_id' => $oldConfig['scope_id'],
+                'path' => $path, // Use the new path
+                'value' => $oldConfig['value'],
+            ]);
+        }
+    }
+   
+}


### PR DESCRIPTION
This patch is created for copying values from the Bambora pay configuration.

When we want to move from the Bambora pay module to the epay module, this patch will copy the configuration values from the Bambora to epay module.

Screenshot 1: It shows the configuration copied from the bambora pay module.

![image](https://github.com/epay-technology/magento2-payment-module/assets/124759210/0aba8cae-636f-4b98-a9ef-f325dcfb24a1)  