### PR TITLE
Fixed error in age verification when order has no shipping address

### DIFF
--- a/Model/Method/Epay/Payment.php
+++ b/Model/Method/Epay/Payment.php
@@ -166,7 +166,7 @@ class Payment extends \Epay\Payment\Model\Method\AbstractPayment implements
         unset($paymentRequest->ageverificationid);
         unset($paymentRequest->ageverificationcountry);
 
-        if($ageVerificationMode == EpayConstants::AGEVERIFICATION_ENABLED_ALL || ($ageVerificationMode == EpayConstants::AGEVERIFICATION_ENABLED_DK && $order->getShippingAddress()->getCountryId() == "DK"))
+        if($ageVerificationMode == EpayConstants::AGEVERIFICATION_ENABLED_ALL || ($ageVerificationMode == EpayConstants::AGEVERIFICATION_ENABLED_DK && $order->getShippingAddress()?->getCountryId() == "DK"))
         {
             $minimumuserage = 0;
             $orderItems = $order->getAllVisibleItems();


### PR DESCRIPTION
This can happen for example when an order contains only virtual products.